### PR TITLE
Add note about `active: true` to advanced confiigs

### DIFF
--- a/esp32-generic.yaml
+++ b/esp32-generic.yaml
@@ -31,8 +31,9 @@ esp32_ble_tracker:
   scan_parameters:
     interval: 1100ms
     window: 1100ms
-    active: true
-
+    active: true # to minimize RF pollution and save some battery you can set this 
+                 # to false if your sensors send advertisment packets by themselves
+                 # and don't require active queries to send data
 bluetooth_proxy:
 
 button:

--- a/m5stack-atom-lite.yaml
+++ b/m5stack-atom-lite.yaml
@@ -31,8 +31,9 @@ esp32_ble_tracker:
   scan_parameters:
     interval: 1100ms
     window: 1100ms
-    active: true
-
+    active: true # to minimize RF pollution and save some battery you can set this 
+                 # to false if your sensors send advertisment packets by themselves
+                 # and don't require active queries to send data
 bluetooth_proxy:
 
 button:

--- a/olimex-esp32-poe-iso.yaml
+++ b/olimex-esp32-poe-iso.yaml
@@ -32,8 +32,9 @@ esp32_ble_tracker:
   scan_parameters:
     interval: 1100ms
     window: 1100ms
-    active: true
-
+    active: true # to minimize RF pollution and save some battery you can set this 
+                 # to false if your sensors send advertisment packets by themselves
+                 # and don't require active queries to send data
 bluetooth_proxy:
 
 button:

--- a/wt32-eth01.yaml
+++ b/wt32-eth01.yaml
@@ -32,8 +32,9 @@ esp32_ble_tracker:
   scan_parameters:
     interval: 1100ms
     window: 1100ms
-    active: true
-
+    active: true # to minimize RF pollution and save some battery you can set this 
+                 # to false if your sensors send advertisment packets by themselves
+                 # and don't require active queries to send data
 bluetooth_proxy:
 
 button:


### PR DESCRIPTION
Devices like ATC MiThermometer (LYWSD03MMC) don't need active polling via Bluetooth, this is just a note for advanced people that it's worth trying with `active: falsee` too.