### PR TITLE
Small cleanups to the bluetooth proxies page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -241,20 +241,18 @@
         </ul>
       </div>
 
-      <div>
-        <h3>Advanced Users</h3>
-        <ul>
-          <li>
-            The device is adoptable in
-            <a
-              href="https://my.home-assistant.io/redirect/supervisor_addon/?addon=5c53de3b_esphome&repository_url=https%3A%2F%2Fgithub.com%2Fesphome%2Fhome-assistant-addon"
-              >the ESPHome dashboard</a>
-          </li>
-          <li>
-            The YAML configuration is on <a href="https://github.com/esphome/bluetooth-proxies/">GitHub</a>
-          </li>
-        </ul>
-      </div>
+      <h3>Advanced Users</h3>
+      <ul>
+        <li>
+          The device is adoptable in
+          <a
+            href="https://my.home-assistant.io/redirect/supervisor_addon/?addon=5c53de3b_esphome&repository_url=https%3A%2F%2Fgithub.com%2Fesphome%2Fhome-assistant-addon"
+            >the ESPHome dashboard</a>
+        </li>
+        <li>
+          The YAML configuration is on <a href="https://github.com/esphome/bluetooth-proxies/">GitHub</a>
+        </li>
+      </ul>
 
       <div class="footer">
         Affiliated links are used on this website to support ESPHome

--- a/static/index.html
+++ b/static/index.html
@@ -208,7 +208,7 @@
           </li>
           <li>
             <a
-              href="https://www.mouser.com/ProductDetail/Olimex-Ltd/ESP32-POE-ISO-EA?qs=%252B6g0mu59x7KfK%2FIl1ERS8Q%3D%3D"
+              href="https://www.mouser.com/ProductDetail/Olimex-Ltd/ESP32-POE-ISO?qs=sGAEpiMZZMuqBwn8WqcFUj2aNd7i9W7uc087HzBKguU1UBkflb3j3w%3D%3D"
               >Mouser</a
             >
           </li>

--- a/static/index.html
+++ b/static/index.html
@@ -191,6 +191,9 @@
           using Power over Ethernet 802.3af. Note that when installed via this
           website, Wi-Fi is disabled and it requires an Ethernet connection for
           further operation.
+
+          The <i>ESP32-POE-ISO-EA</i> variant may provide better Bluetooth range since
+          it has an external antennae.
           <a href="https://www.thingiverse.com/thing:3857281"
             >Case on Thingiverse.</a
           >
@@ -199,13 +202,13 @@
         <ul>
           <li>
             <a
-              href="https://www.olimex.com/Products/IoT/ESP32/ESP32-POE-ISO/open-source-hardware"
+              href="https://www.olimex.com/Products/IoT/ESP32/ESP32-POE-ISO-EA/open-source-hardware"
               >Olimex</a
             >
           </li>
           <li>
             <a
-              href="https://www.mouser.com/ProductDetail/Olimex-Ltd/ESP32-POE-ISO"
+              href="https://www.mouser.com/ProductDetail/Olimex-Ltd/ESP32-POE-ISO-EA?qs=%252B6g0mu59x7KfK%2FIl1ERS8Q%3D%3D"
               >Mouser</a
             >
           </li>
@@ -238,20 +241,20 @@
         </ul>
       </div>
 
-      <p>
-        <i>
-          For advanced users that want to customize the firmware: the device is
-          adoptable in
-          <a
-            href="https://my.home-assistant.io/redirect/supervisor_addon/?addon=5c53de3b_esphome&repository_url=https%3A%2F%2Fgithub.com%2Fesphome%2Fhome-assistant-addon"
-            >the ESPHome dashboard</a
-          >
-          and
-          <a href="https://github.com/esphome/bluetooth-proxies/"
-            >configuration is on GitHub</a
-          >.
-        </i>
-      </p>
+      <div>
+        <h3>Advanced Users</h3>
+        <ul>
+          <li>
+            The device is adoptable in
+            <a
+              href="https://my.home-assistant.io/redirect/supervisor_addon/?addon=5c53de3b_esphome&repository_url=https%3A%2F%2Fgithub.com%2Fesphome%2Fhome-assistant-addon"
+              >the ESPHome dashboard</a>
+          </li>
+          <li>
+            The YAML configuration is on <a href="https://github.com/esphome/bluetooth-proxies/">GitHub</a>
+          </li>
+        </ul>
+      </div>
 
       <div class="footer">
         Affiliated links are used on this website to support ESPHome


### PR DESCRIPTION
- Make the advanced links more discoverable for
  non-chrome users

- Fix the mouser link for the Olimex board

- Switch to linking to the Olimex board with
  an external antennae