### PR TITLE
Hide DIY boards

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -86,8 +86,7 @@
       .radios label {
         padding: 4px;
         cursor: pointer;
-        width: calc(33.333% - 16px);
-        max-width: 184px;
+        width: calc(25% - 16px);
         display: block;
         position: relative;
       }
@@ -156,10 +155,13 @@
           <input type="radio" name="type" value="m5stack-atom-lite" />
           <img src="./m5stack_atom_lite.png" alt="M5Stack Atom Lite" />
         </label>
-        <label>
-          <input type="radio" name="type" value="gl-s10" />
-          <img src="./gl-s10.png" alt="GL.iNet GL-S10" />
-        </label>
+        <!--
+          Requires DIY
+          <label>
+            <input type="radio" name="type" value="gl-s10" />
+            <img src="./gl-s10.png" alt="GL.iNet GL-S10" />
+          </label>
+        -->
         <label>
           <input type="radio" name="type" value="olimex-esp32-poe-iso" />
           <img
@@ -171,10 +173,13 @@
           <input type="radio" name="type" value="wt32-eth01" />
           <img src="./wt32-eth01.png" alt="Wireless-Tag WT32-ETH01" />
         </label>
-        <label>
-          <input type="radio" name="type" value="lilygo-t-eth-poe" />
-          <img src="./lilygo-eth-poe.png" alt="LilyGO T-ETH-POE" />
-        </label>
+        <!--
+          Requires DIY
+          <label>
+            <input type="radio" name="type" value="lilygo-t-eth-poe" />
+            <img src="./lilygo-eth-poe.png" alt="LilyGO T-ETH-POE" />
+          </label>
+        -->
       </div>
 
       <p class="button-row" align="center">


### PR DESCRIPTION
I was reading @blakadder [post on the GL-10](https://blakadder.com/gl-s10/) and I realized that you can't flash the ESP32 via the micro-usb port on the device, you need to open the device. 

That's not a device that we should recommend on this website. This website is only for devices that a user can buy and install without requiring extra things. After review, I realized that lily go added by @kquinsland also cannot be flashed via USB.

This PR hides both.