### PR TITLE
Hide wireless tag

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -86,7 +86,7 @@
       .radios label {
         padding: 4px;
         cursor: pointer;
-        width: calc(25% - 16px);
+        width: calc(33.3% - 16px);
         display: block;
         position: relative;
       }
@@ -169,10 +169,13 @@
             alt="Olimex ESP32 Power-over-Ethernet ISO"
           />
         </label>
-        <label>
-          <input type="radio" name="type" value="wt32-eth01" />
-          <img src="./wt32-eth01.png" alt="Wireless-Tag WT32-ETH01" />
-        </label>
+        <!--
+          Requires DIY
+          <label>
+            <input type="radio" name="type" value="wt32-eth01" />
+            <img src="./wt32-eth01.png" alt="Wireless-Tag WT32-ETH01" />
+          </label>
+        -->
         <!--
           Requires DIY
           <label>


### PR DESCRIPTION
Follow-up to #16. Wireless tag does not have a USB port to allow to flash it.