### PR TITLE
Add link to TubesZB WT32-ETH01 Kit

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -322,6 +322,12 @@
               >Mouser</a
             >
           </li>
+          <li>
+            <a
+              href="https://www.tubeszb.com/product/wt32-eth01-bluetooth-proxy-kit/53"
+              >TubesZB - Kit with enlosure and USB-C</a
+            >
+          </li>
         </ul>
       </div>
 


### PR DESCRIPTION
Adds link to TubesZB for WT32-ETH01 - with serial, USB-C and enclosure.