### PR TITLE
Fix active: true from bluetooth proxy

### DIFF
--- a/esp32-generic.yaml
+++ b/esp32-generic.yaml
@@ -34,7 +34,6 @@ esp32_ble_tracker:
     active: true
 
 bluetooth_proxy:
-  active: true
 
 button:
 - platform: safe_mode


### PR DESCRIPTION
I tried to install a bluetooth proxy from the website, which includes this repo for the files.
But I got an error saying:
`[active] is an invalid option for [bluetooth proxy]` 
After removing it from the config Esphome compiles again (for the generic board).

ESPHome version 2022.9.2

I only found the error after adopting it to my esphome