### PR TITLE
Switch proxies to use esp-idf instead of arduino

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     name: Building ${{ matrix.file }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         file:
           - m5stack-atom-lite.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
         uses: esphome/build-action@v1.5.2
         with:
           yaml_file: ${{ matrix.file }}
-          version: latest
+          version: beta

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       name: M5 Stack Atom Lite
       manifest_filename: m5stack-atom-lite-manifest.json
       clean: false
-      esphome_version: latest
+      esphome_version: beta
 
   publish-esp32-generic:
     name: Publish ESP32 Generic
@@ -25,7 +25,7 @@ jobs:
       name: ESP32 Generic
       manifest_filename: esp32-generic-manifest.json
       clean: false
-      esphome_version: latest
+      esphome_version: beta
 
   publish-olimex-esp32-poe-iso:
     name: Publish Olimex PoE ISO
@@ -35,7 +35,7 @@ jobs:
       name: Olimex PoE ISO
       manifest_filename: olimex-esp32-poe-iso-manifest.json
       clean: false
-      esphome_version: latest
+      esphome_version: beta
 
   publish-wt32-eth01:
     name: Publish Wireless-Tag WT32-ETH01
@@ -45,7 +45,7 @@ jobs:
       name: Wireless-Tag WT32-ETH01
       manifest_filename: wt32-eth01-manifest.json
       clean: false
-      esphome_version: latest
+      esphome_version: beta
 
   publish-gl-s10:
     name: Publish GL.iNet GL-S10
@@ -55,7 +55,7 @@ jobs:
       name: GL.iNet GL-S10
       manifest_filename: gl-s10-manifest.json
       clean: false
-      esphome_version: latest
+      esphome_version: beta
 
   publish-lilygo-t-eth-poe:
     name: Publish LilyGO T-ETH-POE ESP32-WROOM
@@ -65,4 +65,4 @@ jobs:
       name: LilyGO T-ETH-POE
       manifest_filename: lilygo-t-eth-poe-manifest.json
       clean: false
-      esphome_version: latest
+      esphome_version: beta

--- a/esp32-generic.yaml
+++ b/esp32-generic.yaml
@@ -12,7 +12,7 @@ esphome:
 esp32:
   board: esp32dev
   framework:
-    type: arduino
+    type: esp-idf
 
 wifi:
   ap:

--- a/esp32-generic.yaml
+++ b/esp32-generic.yaml
@@ -22,7 +22,7 @@ api:
 logger:
 ota:
 improv_serial:
-captive_portal:
+# captive_portal:
 
 dashboard_import:
   package_import_url: github://esphome/bluetooth-proxies/esp32-generic.yaml@main

--- a/gl-s10.yaml
+++ b/gl-s10.yaml
@@ -17,7 +17,7 @@ esphome:
 esp32:
   board: esp32doit-devkit-v1
   framework:
-    type: arduino
+    type: esp-idf
 
 # Configuration fo V2.3 hardware revision
 ethernet:

--- a/lilygo-t-eth-poe.yaml
+++ b/lilygo-t-eth-poe.yaml
@@ -14,7 +14,7 @@ esp32:
   # See: https://github.com/Xinyuan-LilyGO/LilyGO-T-ETH-POE
   board: esp32dev
   framework:
-    type: arduino
+    type: esp-idf
 
 # See: https://esphome.io/components/ethernet.html#configuration-for-lilygo-ttgo-t-internet-poe-esp32-wroom-lan8270a-chip
 ethernet:

--- a/m5stack-atom-lite.yaml
+++ b/m5stack-atom-lite.yaml
@@ -22,7 +22,7 @@ api:
 logger:
 ota:
 improv_serial:
-captive_portal:
+# captive_portal:
 
 dashboard_import:
   package_import_url: github://esphome/bluetooth-proxies/m5stack-atom-lite.yaml@main

--- a/m5stack-atom-lite.yaml
+++ b/m5stack-atom-lite.yaml
@@ -12,7 +12,7 @@ esphome:
 esp32:
   board: m5stack-atom
   framework:
-    type: arduino
+    type: esp-idf
 
 wifi:
   ap:

--- a/olimex-esp32-poe-iso.yaml
+++ b/olimex-esp32-poe-iso.yaml
@@ -11,7 +11,7 @@ esphome:
 esp32:
   board: esp32-poe-iso
   framework:
-    type: arduino
+    type: esp-idf
 
 ethernet:
   type: LAN8720

--- a/wt32-eth01.yaml
+++ b/wt32-eth01.yaml
@@ -11,7 +11,7 @@ esphome:
 esp32:
   board: esp32doit-devkit-v1
   framework:
-    type: arduino
+    type: esp-idf
 
 ethernet:
   type: LAN8720


### PR DESCRIPTION
This saves ~50K of ram and makes the proxies more stable, but we need 2022.12.x for this to work.