### PR TITLE
Update esphome version back to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
         uses: esphome/build-action@v1.5.2
         with:
           yaml_file: ${{ matrix.file }}
-          version: beta
+          version: latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       name: M5 Stack Atom Lite
       manifest_filename: m5stack-atom-lite-manifest.json
       clean: false
-      esphome_version: beta
+      esphome_version: latest
 
   publish-esp32-generic:
     name: Publish ESP32 Generic
@@ -25,7 +25,7 @@ jobs:
       name: ESP32 Generic
       manifest_filename: esp32-generic-manifest.json
       clean: false
-      esphome_version: beta
+      esphome_version: latest
 
   publish-olimex-esp32-poe-iso:
     name: Publish Olimex PoE ISO
@@ -35,7 +35,7 @@ jobs:
       name: Olimex PoE ISO
       manifest_filename: olimex-esp32-poe-iso-manifest.json
       clean: false
-      esphome_version: beta
+      esphome_version: latest
 
   publish-wt32-eth01:
     name: Publish Wireless-Tag WT32-ETH01
@@ -45,7 +45,7 @@ jobs:
       name: Wireless-Tag WT32-ETH01
       manifest_filename: wt32-eth01-manifest.json
       clean: false
-      esphome_version: beta
+      esphome_version: latest
 
   publish-gl-s10:
     name: Publish GL.iNet GL-S10
@@ -55,7 +55,7 @@ jobs:
       name: GL.iNet GL-S10
       manifest_filename: gl-s10-manifest.json
       clean: false
-      esphome_version: beta
+      esphome_version: latest
 
   publish-lilygo-t-eth-poe:
     name: Publish LilyGO T-ETH-POE ESP32-WROOM
@@ -65,4 +65,4 @@ jobs:
       name: LilyGO T-ETH-POE
       manifest_filename: lilygo-t-eth-poe-manifest.json
       clean: false
-      esphome_version: beta
+      esphome_version: latest


### PR DESCRIPTION
We had this set to beta since it had critical fixes, but now that they are in latest, we can switch back.