### PR TITLE
Add friendly names

### DIFF
--- a/esp32-generic.yaml
+++ b/esp32-generic.yaml
@@ -1,9 +1,10 @@
 substitutions:
   name: esp32-bluetooth-proxy
-  wifi_ap_password: ""
+  friendly_name: Bluetooth Proxy
 
 esphome:
   name: ${name}
+  friendly_name: ${friendly_name}
   name_add_mac_suffix: true
   project:
     name: esphome.bluetooth-proxy
@@ -16,13 +17,11 @@ esp32:
 
 wifi:
   ap:
-    password: ${wifi_ap_password}
 
 api:
 logger:
 ota:
 improv_serial:
-# captive_portal:
 
 dashboard_import:
   package_import_url: github://esphome/bluetooth-proxies/esp32-generic.yaml@main

--- a/gl-s10.yaml
+++ b/gl-s10.yaml
@@ -2,9 +2,11 @@
 
 substitutions:
   name: gl-s10-bt-proxy
+  friendly_name: Bluetooth Proxy
 
 esphome:
   name: ${name}
+  friendly_name: ${friendly_name}
   name_add_mac_suffix: true
   project:
     name: esphome.bluetooth-proxy

--- a/lilygo-t-eth-poe.yaml
+++ b/lilygo-t-eth-poe.yaml
@@ -1,8 +1,10 @@
 substitutions:
   name: "lilygo-ttgo-poe-bt-proxy"
+  friendly_name: Bluetooth Proxy
 
 esphome:
-  name: "${name}"
+  name: ${name}
+  friendly_name: ${friendly_name}
   name_add_mac_suffix: true
   project:
     name: esphome.bluetooth-proxy

--- a/m5stack-atom-lite.yaml
+++ b/m5stack-atom-lite.yaml
@@ -1,9 +1,10 @@
 substitutions:
   name: atom-bluetooth-proxy
-  wifi_ap_password: ""
+  friendly_name: Bluetooth Proxy
 
 esphome:
   name: ${name}
+  friendly_name: ${friendly_name}
   name_add_mac_suffix: true
   project:
     name: esphome.bluetooth-proxy
@@ -16,13 +17,11 @@ esp32:
 
 wifi:
   ap:
-    password: ${wifi_ap_password}
 
 api:
 logger:
 ota:
 improv_serial:
-# captive_portal:
 
 dashboard_import:
   package_import_url: github://esphome/bluetooth-proxies/m5stack-atom-lite.yaml@main

--- a/olimex-esp32-poe-iso.yaml
+++ b/olimex-esp32-poe-iso.yaml
@@ -1,8 +1,10 @@
 substitutions:
   name: olimex-bluetooth-proxy
+  friendly_name: Bluetooth Proxy
 
 esphome:
   name: ${name}
+  friendly_name: ${friendly_name}
   name_add_mac_suffix: true
   project:
     name: esphome.bluetooth-proxy

--- a/wt32-eth01.yaml
+++ b/wt32-eth01.yaml
@@ -1,8 +1,10 @@
 substitutions:
   name: wt32-eth01-bt-proxy
+  friendly_name: Bluetooth Proxy
 
 esphome:
   name: ${name}
+  friendly_name: ${friendly_name}
   name_add_mac_suffix: true
   project:
     name: esphome.bluetooth-proxy


### PR DESCRIPTION
Also removes the ap_password substitution as its quite easy for users to add one in the adopted yaml if needed