### PR TITLE
Adjust wifi based proxies for coexistence

### DIFF
--- a/esp32-generic.yaml
+++ b/esp32-generic.yaml
@@ -29,7 +29,7 @@ dashboard_import:
 esp32_ble_tracker:
   scan_parameters:
     interval: 450ms
-    window: 450ms
+    window: 160ms
     active: true
 
 bluetooth_proxy:

--- a/esp32-generic.yaml
+++ b/esp32-generic.yaml
@@ -28,8 +28,6 @@ dashboard_import:
 
 esp32_ble_tracker:
   scan_parameters:
-    interval: 450ms
-    window: 160ms
     active: true
 
 bluetooth_proxy:

--- a/esp32-generic.yaml
+++ b/esp32-generic.yaml
@@ -29,7 +29,7 @@ dashboard_import:
 esp32_ble_tracker:
   scan_parameters:
     # We currently use the defaults to ensure Bluetooth
-    # can co-exist with WiFi In the future we may be able to 
+    # can co-exist with WiFi In the future we may be able to
     # enable the built-in coexistence logic in ESP-IDF
     active: true
 

--- a/esp32-generic.yaml
+++ b/esp32-generic.yaml
@@ -28,8 +28,9 @@ dashboard_import:
 
 esp32_ble_tracker:
   scan_parameters:
-# We currently use the defaults to ensure Bluetooth can co-exist with WiFi
-# In the future we may be able to enable the built-in coexistence logic in ESP-IDF
+    # We currently use the defaults to ensure Bluetooth
+    # can co-exist with WiFi In the future we may be able to 
+    # enable the built-in coexistence logic in ESP-IDF
     active: true
 
 bluetooth_proxy:

--- a/esp32-generic.yaml
+++ b/esp32-generic.yaml
@@ -29,7 +29,7 @@ dashboard_import:
 esp32_ble_tracker:
   scan_parameters:
     interval: 450ms
-    window: 150ms
+    window: 450ms
     active: true
 
 bluetooth_proxy:

--- a/esp32-generic.yaml
+++ b/esp32-generic.yaml
@@ -28,8 +28,8 @@ dashboard_import:
 
 esp32_ble_tracker:
   scan_parameters:
-    interval: 1100ms
-    window: 1100ms
+    interval: 450ms
+    window: 150ms
     active: true
 
 bluetooth_proxy:

--- a/esp32-generic.yaml
+++ b/esp32-generic.yaml
@@ -28,6 +28,8 @@ dashboard_import:
 
 esp32_ble_tracker:
   scan_parameters:
+# We currently use the defaults to ensure Bluetooth can co-exist with WiFi
+# In the future we may be able to enable the built-in coexistence logic in ESP-IDF
     active: true
 
 bluetooth_proxy:

--- a/m5stack-atom-lite.yaml
+++ b/m5stack-atom-lite.yaml
@@ -29,7 +29,7 @@ dashboard_import:
 esp32_ble_tracker:
   scan_parameters:
     interval: 450ms
-    window: 450ms
+    window: 160ms
     active: true
 
 bluetooth_proxy:

--- a/m5stack-atom-lite.yaml
+++ b/m5stack-atom-lite.yaml
@@ -28,8 +28,6 @@ dashboard_import:
 
 esp32_ble_tracker:
   scan_parameters:
-    interval: 450ms
-    window: 160ms
     active: true
 
 bluetooth_proxy:

--- a/m5stack-atom-lite.yaml
+++ b/m5stack-atom-lite.yaml
@@ -29,7 +29,7 @@ dashboard_import:
 esp32_ble_tracker:
   scan_parameters:
     # We currently use the defaults to ensure Bluetooth
-    # can co-exist with WiFi In the future we may be able to 
+    # can co-exist with WiFi In the future we may be able to
     # enable the built-in coexistence logic in ESP-IDF
     active: true
 

--- a/m5stack-atom-lite.yaml
+++ b/m5stack-atom-lite.yaml
@@ -28,8 +28,9 @@ dashboard_import:
 
 esp32_ble_tracker:
   scan_parameters:
-# We currently use the defaults to ensure Bluetooth can co-exist with WiFi
-# In the future we may be able to enable the built-in coexistence logic in ESP-IDF
+    # We currently use the defaults to ensure Bluetooth
+    # can co-exist with WiFi In the future we may be able to 
+    # enable the built-in coexistence logic in ESP-IDF
     active: true
 
 bluetooth_proxy:

--- a/m5stack-atom-lite.yaml
+++ b/m5stack-atom-lite.yaml
@@ -29,7 +29,7 @@ dashboard_import:
 esp32_ble_tracker:
   scan_parameters:
     interval: 450ms
-    window: 150ms
+    window: 450ms
     active: true
 
 bluetooth_proxy:

--- a/m5stack-atom-lite.yaml
+++ b/m5stack-atom-lite.yaml
@@ -28,8 +28,8 @@ dashboard_import:
 
 esp32_ble_tracker:
   scan_parameters:
-    interval: 1100ms
-    window: 1100ms
+    interval: 450ms
+    window: 150ms
     active: true
 
 bluetooth_proxy:

--- a/m5stack-atom-lite.yaml
+++ b/m5stack-atom-lite.yaml
@@ -28,6 +28,8 @@ dashboard_import:
 
 esp32_ble_tracker:
   scan_parameters:
+# We currently use the defaults to ensure Bluetooth can co-exist with WiFi
+# In the future we may be able to enable the built-in coexistence logic in ESP-IDF
     active: true
 
 bluetooth_proxy:


### PR DESCRIPTION
fixes #67

https://espressif-docs.readthedocs-hosted.com/projects/espressif-esp-faq/en/latest/software-framework/ble-bt.html#how-do-esp32-bluetooth-and-wi-fi-coexist

If the Bluetooth LE and Wi-Fi coexistence is required.....However, if this option is not enabled, please note that the Bluetooth LE scan window should be larger than 150 ms, and the Bluetooth LE scan interval should be less than 500 ms.

https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/coexist.html

We will use the defaults for the wifi versions leave the 1100ms for ethernet as this makes the devices stable and avoids the wifi disconnect problem.

In a future PR we may be able to enable the built-in coexistence logic in the ESP-IDF code, but that is a more involved change.
