### PR TITLE
Dedecated config for gl-s10 Hardware Revision V1.0

### DIFF
--- a/gl-s10-hardware-revision-V1.0.yaml
+++ b/gl-s10-hardware-revision-V1.0.yaml
@@ -21,16 +21,6 @@ esp32:
   framework:
     type: esp-idf
 
-# Configuration fo V2.3 hardware revision
-# ethernet:
-#   type: IP101
-#   mdc_pin: GPIO23
-#   mdio_pin: GPIO18
-#   clk_mode: GPIO17_OUT
-#   phy_addr: 1
-#   power_pin: GPIO5
-
-# Comment the above and use this instead for V1.0 revision of the hardware
 ethernet:
   type: LAN8720
   mdc_pin: GPIO23

--- a/gl-s10_hardware-revision_1.x.yaml
+++ b/gl-s10_hardware-revision_1.x.yaml
@@ -22,21 +22,21 @@ esp32:
     type: esp-idf
 
 # Configuration fo V2.3 hardware revision
-ethernet:
-  type: IP101
-  mdc_pin: GPIO23
-  mdio_pin: GPIO18
-  clk_mode: GPIO17_OUT
-  phy_addr: 1
-  power_pin: GPIO5
-
-# Comment the above and use this instead for V1.0 revision of the hardware
 # ethernet:
-#   type: LAN8720
+#   type: IP101
 #   mdc_pin: GPIO23
 #   mdio_pin: GPIO18
 #   clk_mode: GPIO17_OUT
 #   phy_addr: 1
+#   power_pin: GPIO5
+
+# Comment the above and use this instead for V1.0 revision of the hardware
+ethernet:
+  type: LAN8720
+  mdc_pin: GPIO23
+  mdio_pin: GPIO18
+  clk_mode: GPIO17_OUT
+  phy_addr: 1
 
 api:
 logger:


### PR DESCRIPTION
Since the gl-s10 devices share all the base configuration and source except the difference between the configuration of Ethernet port, It's better to create a dedicated configs file for each "Hardware Revision" that has a difference.
This way we don't need any unofficial forks to support multi Hardware Revisions. 
I've created a pull request only adding a dedecated config for the V1.0 Hardware Revision of the gl-s10, since its a new file and won't affect any users. I would suggest to "change" the original  gl-s10.yml to the supported Hardware Revisions - but this may lead to issues with users already using it as a url of the config file. Still think its a better way to support multi versioning of devices from the same source without fragmenting the updates and maintenance.