### PR TITLE
Add comment for v2.1 of GL-S10

### DIFF
--- a/gl-s10.yaml
+++ b/gl-s10.yaml
@@ -30,6 +30,15 @@ ethernet:
   phy_addr: 1
   power_pin: GPIO5
 
+# Comment the above and use this instead for V2.1 revision of the hardware
+# ethernet:
+#   type: IP101
+#   mdc_pin: GPIO23
+#   mdio_pin: GPIO18
+#   clk_mode: GPIO0_IN
+#   phy_addr: 1
+#   power_pin: GPIO5
+
 # Comment the above and use this instead for V1.0 revision of the hardware
 # ethernet:
 #   type: LAN8720


### PR DESCRIPTION
Adds a comment which describes the config for v2.1 of the hardware to resolve packet loss issues.