### PR TITLE
Ignore warning about strapping pins for Olimex ESP32-POE-ISO ethernet configuration

### DIFF
--- a/olimex/olimex-esp32-poe-iso.yaml
+++ b/olimex/olimex-esp32-poe-iso.yaml
@@ -15,7 +15,9 @@ ethernet:
   mdio_pin: GPIO18
   clk_mode: GPIO17_OUT
   phy_addr: 0
-  power_pin: GPIO12
+  power_pin:
+    number: GPIO12
+    ignore_strapping_warning: true
 
 api:
 logger:


### PR DESCRIPTION
GPIO12 raise a warning about straping pin, which can be ignored as it is the expected configuration.
