### PR TITLE
Update deprecated clk_mode to clk configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         esp32-generic/esp32-generic-c3.factory.yaml
         esp32-generic/esp32-generic-c6.factory.yaml
         esp32-generic/esp32-generic-s3.factory.yaml
-      esphome-version: 2025.5.0
+      esphome-version: 2025.7.0
       combined-name: esp32-generic
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
@@ -40,7 +40,7 @@ jobs:
         m5stack/m5stack-atom-s3.factory.yaml
         olimex/olimex-esp32-poe-iso.factory.yaml
         wt32/wt32-eth01.factory.yaml
-      esphome-version: 2025.5.0
+      esphome-version: 2025.7.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/gl-inet/gl-s10.yaml
+++ b/gl-inet/gl-s10.yaml
@@ -2,7 +2,7 @@
 esphome:
   name: gl-s10
   friendly_name: Bluetooth Proxy
-  min_version: 2025.5.0
+  min_version: 2025.7.0
   name_add_mac_suffix: true
   # turn on Power LED when esphome boots
   on_boot:

--- a/gl-inet/gl-s10.yaml
+++ b/gl-inet/gl-s10.yaml
@@ -19,7 +19,9 @@ ethernet:
   type: IP101
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO0_IN
+  clk:
+    pin: GPIO0
+    mode: CLK_EXT_IN
   phy_addr: 1
   power_pin: GPIO5
 
@@ -28,7 +30,9 @@ ethernet:
 #   type: LAN8720
 #   mdc_pin: GPIO23
 #   mdio_pin: GPIO18
-#   clk_mode: GPIO17_OUT
+#   clk:
+#     pin: GPIO17
+#     mode: CLK_OUT
 #   phy_addr: 1
 
 api:

--- a/lilygo/lilygo-t-eth-poe.yaml
+++ b/lilygo/lilygo-t-eth-poe.yaml
@@ -17,7 +17,9 @@ ethernet:
   type: LAN8720
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO17_OUT
+  clk:
+    pin: GPIO17
+    mode: CLK_OUT
   phy_addr: 0
 
 api:

--- a/lilygo/lilygo-t-eth-poe.yaml
+++ b/lilygo/lilygo-t-eth-poe.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: lilygo-t-eth-poe
   friendly_name: Bluetooth Proxy
-  min_version: 2025.5.0
+  min_version: 2025.7.0
   name_add_mac_suffix: true
 
 esp32:

--- a/olimex/olimex-esp32-poe-iso.yaml
+++ b/olimex/olimex-esp32-poe-iso.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: olimex-esp32-poe-iso
   friendly_name: Bluetooth Proxy
-  min_version: 2025.5.0
+  min_version: 2025.7.0
   name_add_mac_suffix: true
 
 esp32:

--- a/olimex/olimex-esp32-poe-iso.yaml
+++ b/olimex/olimex-esp32-poe-iso.yaml
@@ -13,7 +13,9 @@ ethernet:
   type: LAN8720
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO17_OUT
+  clk:
+    pin: GPIO17
+    mode: CLK_OUT
   phy_addr: 0
   power_pin:
     number: GPIO12

--- a/wt32/wt32-eth01.yaml
+++ b/wt32/wt32-eth01.yaml
@@ -15,7 +15,9 @@ ethernet:
   type: LAN8720
   mdc_pin: GPIO23
   mdio_pin: GPIO18
-  clk_mode: GPIO0_IN
+  clk:
+    pin: GPIO0
+    mode: CLK_EXT_IN
   phy_addr: 1
   power_pin: GPIO16
 

--- a/wt32/wt32-eth01.yaml
+++ b/wt32/wt32-eth01.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: wt32-eth01
   friendly_name: Bluetooth Proxy
-  min_version: 2025.5.0
+  min_version: 2025.7.0
   name_add_mac_suffix: true
   platformio_options:
     board_build.flash_mode: dio


### PR DESCRIPTION
The `clk_mode` option in ethernet configuration has been deprecated in favor of the new `clk` mapping format. This PR updates all affected configuration files to use the current ESPHome syntax and ensures build compatibility.

## Changes
- Updated gl-inet/gl-s10.yaml: GPIO0_IN → CLK_EXT_IN
- Updated olimex/olimex-esp32-poe-iso.yaml: GPIO17_OUT → CLK_OUT  
- Updated lilygo/lilygo-t-eth-poe.yaml: GPIO17_OUT → CLK_OUT
- Updated wt32/wt32-eth01.yaml: GPIO0_IN → CLK_EXT_IN
- Bumped min_version from 2025.5.0 to 2025.7.0 for all ethernet configs
- Updated GitHub Actions workflow ESPHome version to 2025.7.0

The new format uses a `clk` mapping with `pin` and `mode` keys as documented in the current ESPHome ethernet component docs. The version updates ensure compatibility with ESPHome 2025.7.0+ where the new clk format was introduced.

Hat tip to @bikeymouse for bringing this to attention.

Closes #122