### PR TITLE
Use esp32 variant instead of board

### DIFF
--- a/esp32-generic/esp32-generic-c3.yaml
+++ b/esp32-generic/esp32-generic-c3.yaml
@@ -1,11 +1,11 @@
 esphome:
   name: esp32-bluetooth-proxy
   friendly_name: Bluetooth Proxy
-  min_version: 2025.5.0
+  min_version: 2025.8.0
   name_add_mac_suffix: true
 
 esp32:
-  board: esp32-c3-devkitm-1
+  variant: esp32c3
   framework:
     type: esp-idf
     sdkconfig_options:

--- a/esp32-generic/esp32-generic-c6.yaml
+++ b/esp32-generic/esp32-generic-c6.yaml
@@ -1,11 +1,11 @@
 esphome:
   name: esp32-bluetooth-proxy
   friendly_name: Bluetooth Proxy
-  min_version: 2025.5.0
+  min_version: 2025.8.0
   name_add_mac_suffix: true
 
 esp32:
-  board: esp32-c6-devkitc-1
+  variant: esp32c6
   framework:
     type: esp-idf
 

--- a/esp32-generic/esp32-generic-s3.yaml
+++ b/esp32-generic/esp32-generic-s3.yaml
@@ -1,11 +1,11 @@
 esphome:
   name: esp32-bluetooth-proxy
   friendly_name: Bluetooth Proxy
-  min_version: 2025.5.0
+  min_version: 2025.8.0
   name_add_mac_suffix: true
 
 esp32:
-  board: esp32-s3-devkitc-1
+  variant: esp32s3
   framework:
     type: esp-idf
 

--- a/esp32-generic/esp32-generic.yaml
+++ b/esp32-generic/esp32-generic.yaml
@@ -1,11 +1,11 @@
 esphome:
   name: esp32-bluetooth-proxy
   friendly_name: Bluetooth Proxy
-  min_version: 2025.5.0
+  min_version: 2025.8.0
   name_add_mac_suffix: true
 
 esp32:
-  board: esp32dev
+  variant: esp32
   framework:
     type: esp-idf
 

--- a/gl-inet/gl-s10.yaml
+++ b/gl-inet/gl-s10.yaml
@@ -2,7 +2,7 @@
 esphome:
   name: gl-s10
   friendly_name: Bluetooth Proxy
-  min_version: 2025.7.0
+  min_version: 2025.8.0
   name_add_mac_suffix: true
   # turn on Power LED when esphome boots
   on_boot:
@@ -10,7 +10,7 @@ esphome:
       - output.turn_on: power_led
 
 esp32:
-  board: esp32doit-devkit-v1
+  variant: esp32
   framework:
     type: esp-idf
 

--- a/lilygo/lilygo-t-eth-poe.yaml
+++ b/lilygo/lilygo-t-eth-poe.yaml
@@ -1,14 +1,11 @@
 esphome:
   name: lilygo-t-eth-poe
   friendly_name: Bluetooth Proxy
-  min_version: 2025.7.0
+  min_version: 2025.8.0
   name_add_mac_suffix: true
 
 esp32:
-  # Platform.io does not have an explicit profile for the module.
-  # We can treat it like a standard dev board based around a standard WROOM module.
-  # See: https://github.com/Xinyuan-LilyGO/LilyGO-T-ETH-POE
-  board: esp32dev
+  variant: esp32
   framework:
     type: esp-idf
 

--- a/m5stack/m5stack-atom-lite.yaml
+++ b/m5stack/m5stack-atom-lite.yaml
@@ -1,11 +1,11 @@
 esphome:
   name: m5stack-atom-lite
   friendly_name: Bluetooth Proxy
-  min_version: 2025.5.0
+  min_version: 2025.8.0
   name_add_mac_suffix: true
 
 esp32:
-  board: m5stack-atom
+  variant: esp32
   framework:
     type: esp-idf
 

--- a/m5stack/m5stack-atom-s3.yaml
+++ b/m5stack/m5stack-atom-s3.yaml
@@ -1,11 +1,11 @@
 esphome:
   name: m5stack-atom-s3
   friendly_name: Bluetooth Proxy
-  min_version: 2025.5.0
+  min_version: 2025.8.0
   name_add_mac_suffix: true
 
 esp32:
-  board: m5stack-atoms3
+  variant: esp32s3
   framework:
     type: esp-idf
 

--- a/olimex/olimex-esp32-poe-iso.yaml
+++ b/olimex/olimex-esp32-poe-iso.yaml
@@ -1,11 +1,11 @@
 esphome:
   name: olimex-esp32-poe-iso
   friendly_name: Bluetooth Proxy
-  min_version: 2025.7.0
+  min_version: 2025.8.0
   name_add_mac_suffix: true
 
 esp32:
-  board: esp32-poe-iso
+  variant: esp32
   framework:
     type: esp-idf
 

--- a/wt32/wt32-eth01.yaml
+++ b/wt32/wt32-eth01.yaml
@@ -1,13 +1,13 @@
 esphome:
   name: wt32-eth01
   friendly_name: Bluetooth Proxy
-  min_version: 2025.7.0
+  min_version: 2025.8.0
   name_add_mac_suffix: true
   platformio_options:
     board_build.flash_mode: dio
 
 esp32:
-  board: wt32-eth01
+  variant: esp32
   framework:
     type: esp-idf
 


### PR DESCRIPTION
ESPHome [2025.8.0 allows](https://github.com/esphome/esphome/pull/9427) for variant only and the generic board for that variant will be used where needed.