### PR TITLE
Bump ESPHome version to 2025.11.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         esp32-generic/esp32-generic-c3.factory.yaml
         esp32-generic/esp32-generic-c6.factory.yaml
         esp32-generic/esp32-generic-s3.factory.yaml
-      esphome-version: 2025.8.2
+      esphome-version: 2025.11.2
       combined-name: esp32-generic
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
@@ -40,7 +40,7 @@ jobs:
         m5stack/m5stack-atom-s3.factory.yaml
         olimex/olimex-esp32-poe-iso.factory.yaml
         wt32/wt32-eth01.factory.yaml
-      esphome-version: 2025.8.2
+      esphome-version: 2025.11.2
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}


### PR DESCRIPTION
I got the following repair in HA, so here we're :grimacing: 

> ESPHome 2025.11.0 introduces ultra-low latency event processing, reducing BLE event delays from 0-16 milliseconds to approximately 12 microseconds. This resolves stability issues when pairing, connecting, or handshaking with devices that require low latency, and makes Bluetooth proxy operations rival or exceed local adapters. We highly recommend updating esp32-bluetooth-proxy-0fe814 to take advantage of these improvements.