### PR TITLE
Fix Seeed device name to match file paths

### DIFF
--- a/seeed/seeed-esp32-poe.yaml
+++ b/seeed/seeed-esp32-poe.yaml
@@ -1,6 +1,6 @@
 # Only boards produced after November 1, 2025 are supported
 esphome:
-  name: seeed-esp32-s3
+  name: seeed-esp32-poe
   friendly_name: Bluetooth Proxy
   min_version: 2025.8.0
   name_add_mac_suffix: true


### PR DESCRIPTION
## Description
Changes `esphome.name` from `seeed-esp32-s3` to `seeed-esp32-poe` to match the file names and firmware manifest URL paths.

Without this fix, the firmware manifest would be published to `seeed-esp32-s3/manifest.json` but the factory config and web installer expect it at `seeed-esp32-poe/manifest.json`, resulting in a 404.

I missed they didn't match in review https://github.com/esphome/bluetooth-proxies/pull/137