### PR TITLE
Increase connection slots to 4 for ethernet proxies

### DIFF
--- a/gl-inet/gl-s10.yaml
+++ b/gl-inet/gl-s10.yaml
@@ -2,7 +2,7 @@
 esphome:
   name: gl-s10
   friendly_name: Bluetooth Proxy
-  min_version: 2025.8.0
+  min_version: 2025.11.0
   name_add_mac_suffix: true
   # turn on Power LED when esphome boots
   on_boot:
@@ -41,6 +41,9 @@ ota:
   - platform: esphome
     id: ota_esphome
 
+esp32_ble:
+  max_connections: 4
+
 esp32_ble_tracker:
   scan_parameters:
     interval: 1100ms
@@ -61,6 +64,7 @@ esp32_ble_tracker:
 
 bluetooth_proxy:
   active: true
+  connection_slots: 4
 
 button:
   - platform: safe_mode

--- a/lilygo/lilygo-t-eth-poe.yaml
+++ b/lilygo/lilygo-t-eth-poe.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: lilygo-t-eth-poe
   friendly_name: Bluetooth Proxy
-  min_version: 2025.8.0
+  min_version: 2025.11.0
   name_add_mac_suffix: true
 
 esp32:
@@ -25,6 +25,9 @@ ota:
   - platform: esphome
     id: ota_esphome
 
+esp32_ble:
+  max_connections: 4
+
 esp32_ble_tracker:
   scan_parameters:
     interval: 1100ms
@@ -33,6 +36,7 @@ esp32_ble_tracker:
 
 bluetooth_proxy:
   active: true
+  connection_slots: 4
 
 button:
   - platform: safe_mode

--- a/olimex/olimex-esp32-poe-iso.yaml
+++ b/olimex/olimex-esp32-poe-iso.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: olimex-esp32-poe-iso
   friendly_name: Bluetooth Proxy
-  min_version: 2025.8.0
+  min_version: 2025.11.0
   name_add_mac_suffix: true
 
 esp32:
@@ -27,6 +27,9 @@ ota:
   - platform: esphome
     id: ota_esphome
 
+esp32_ble:
+  max_connections: 4
+
 esp32_ble_tracker:
   scan_parameters:
     interval: 1100ms
@@ -35,6 +38,7 @@ esp32_ble_tracker:
 
 bluetooth_proxy:
   active: true
+  connection_slots: 4
 
 button:
   - platform: safe_mode

--- a/seeed/seeed-esp32-poe.yaml
+++ b/seeed/seeed-esp32-poe.yaml
@@ -2,7 +2,7 @@
 esphome:
   name: seeed-esp32-poe
   friendly_name: Bluetooth Proxy
-  min_version: 2025.8.0
+  min_version: 2025.11.0
   name_add_mac_suffix: true
 
 esp32:
@@ -25,10 +25,14 @@ ota:
   - platform: esphome
     id: ota_esphome
 
+esp32_ble:
+  max_connections: 4
+
 esp32_ble_tracker:
 
 bluetooth_proxy:
   active: true
+  connection_slots: 4
 
 button:
   - platform: safe_mode

--- a/wt32/wt32-eth01.yaml
+++ b/wt32/wt32-eth01.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: wt32-eth01
   friendly_name: Bluetooth Proxy
-  min_version: 2025.8.0
+  min_version: 2025.11.0
   name_add_mac_suffix: true
   platformio_options:
     board_build.flash_mode: dio
@@ -27,6 +27,9 @@ ota:
   - platform: esphome
     id: ota_esphome
 
+esp32_ble:
+  max_connections: 4
+
 esp32_ble_tracker:
   scan_parameters:
     interval: 1100ms
@@ -35,6 +38,7 @@ esp32_ble_tracker:
 
 bluetooth_proxy:
   active: true
+  connection_slots: 4
 
 button:
   - platform: safe_mode


### PR DESCRIPTION
## Suggested PR Title
Increase connection slots to 4 for ethernet proxies

## Description
Recent versions of ESPHome have significant memory savings and low-latency BLE event processing. This unlocks the ability to have 4 connection slots on ethernet proxies (WiFi proxies share airtime with BLE so they cannot support this increase).

This has been tested in production for almost three months with the olimex boards.

Changes:
- Add `esp32_ble.max_connections: 4` to all ethernet proxy configs
- Add `bluetooth_proxy.connection_slots: 4` to all ethernet proxy configs
- Bump `min_version` to `2025.11.0` (required for these features)

Affected devices:
- olimex-esp32-poe-iso
- lilygo-t-eth-poe
- wt32-eth01
- gl-s10
- seeed-esp32-poe
