### PR TITLE
Remove aggressive scan parameters from PoE proxies

### DIFF
--- a/gl-inet/gl-s10.yaml
+++ b/gl-inet/gl-s10.yaml
@@ -46,8 +46,6 @@ esp32_ble:
 
 esp32_ble_tracker:
   scan_parameters:
-    interval: 1100ms
-    window: 1100ms
     active: true
 #
 # The LED is disabled for ESPHome 2023.6.0+ since we do not

--- a/lilygo/lilygo-t-eth-poe.yaml
+++ b/lilygo/lilygo-t-eth-poe.yaml
@@ -30,8 +30,6 @@ esp32_ble:
 
 esp32_ble_tracker:
   scan_parameters:
-    interval: 1100ms
-    window: 1100ms
     active: true
 
 bluetooth_proxy:

--- a/olimex/olimex-esp32-poe-iso.yaml
+++ b/olimex/olimex-esp32-poe-iso.yaml
@@ -32,8 +32,6 @@ esp32_ble:
 
 esp32_ble_tracker:
   scan_parameters:
-    interval: 1100ms
-    window: 1100ms
     active: true
 
 bluetooth_proxy:

--- a/wt32/wt32-eth01.yaml
+++ b/wt32/wt32-eth01.yaml
@@ -32,8 +32,6 @@ esp32_ble:
 
 esp32_ble_tracker:
   scan_parameters:
-    interval: 1100ms
-    window: 1100ms
     active: true
 
 bluetooth_proxy:


### PR DESCRIPTION
## Summary

Remove aggressive `interval: 1100ms` / `window: 1100ms` scan parameters from PoE-based proxies, restoring ESPHome defaults.

**Historical context:** These values originated from one user optimizing their specific device to maximize Bluetooth airtime. The settings were then copy-pasted into the documentation and subsequently into all PoE proxy configurations, despite providing no real benefit for most setups.

**Why remove:**
- Increases CPU usage unnecessarily
- Can cause overheating on some PoE-based proxies
- ESPHome docs now explicitly recommend using defaults

**Affected devices:**
- Olimex ESP32-PoE-ISO
- LilyGO T-ETH-PoE
- WT32-ETH01
- GL-iNET GL-S10

**Breaking change:** Users who previously relied on these aggressive scan settings will see different (default) behavior after updating. Users can restore custom settings by taking control of the device in their ESPHome dashboard and flashing with their preferred configuration. See [esp32_ble_tracker docs](https://esphome.io/components/esp32_ble_tracker.html) for available options.
