### PR TITLE
Add minimum_chip_revision to esp32-generic.yaml

### DIFF
--- a/esp32-generic/esp32-generic.yaml
+++ b/esp32-generic/esp32-generic.yaml
@@ -8,6 +8,7 @@ esp32:
   variant: esp32
   framework:
     type: esp-idf
+  minimum_chip_revision: "3.1" #to reduce binary size
 
 wifi:
   ap:


### PR DESCRIPTION
Added minimum_chip_revision to reduce binary size.