### PR TITLE
Un-Pin ESP-IDF 5.5.2.260206 as ESPHome 2026.3.0 is out

### DIFF
--- a/esp32-generic/esp32-generic-c3.yaml
+++ b/esp32-generic/esp32-generic-c3.yaml
@@ -8,11 +8,6 @@ esp32:
   variant: esp32c3
   framework:
     type: esp-idf
-    # Workaround for BLE scanning regression (https://github.com/esphome/esphome/issues/13560)
-    # Remove once ESPHome 2026.2.0 is released
-    version: 5.5.2
-    release: "260206"
-    # end remove
     sdkconfig_options:
       CONFIG_BT_BLE_42_FEATURES_SUPPORTED: y
       CONFIG_BT_BLE_50_FEATURES_SUPPORTED: n

--- a/esp32-generic/esp32-generic-c6.yaml
+++ b/esp32-generic/esp32-generic-c6.yaml
@@ -8,11 +8,6 @@ esp32:
   variant: esp32c6
   framework:
     type: esp-idf
-    # Workaround for BLE scanning regression (https://github.com/esphome/esphome/issues/13560)
-    # Remove once ESPHome 2026.2.0 is released
-    version: 5.5.2
-    release: "260206"
-    # end remove
 
 wifi:
   ap:

--- a/esp32-generic/esp32-generic-s3.yaml
+++ b/esp32-generic/esp32-generic-s3.yaml
@@ -8,11 +8,6 @@ esp32:
   variant: esp32s3
   framework:
     type: esp-idf
-    # Workaround for BLE scanning regression (https://github.com/esphome/esphome/issues/13560)
-    # Remove once ESPHome 2026.2.0 is released
-    version: 5.5.2
-    release: "260206"
-    # end remove
 
 wifi:
   ap:

--- a/esp32-generic/esp32-generic.yaml
+++ b/esp32-generic/esp32-generic.yaml
@@ -8,11 +8,6 @@ esp32:
   variant: esp32
   framework:
     type: esp-idf
-    # Workaround for BLE scanning regression (https://github.com/esphome/esphome/issues/13560)
-    # Remove once ESPHome 2026.2.0 is released
-    version: 5.5.2
-    release: "260206"
-    # end remove
 
 wifi:
   ap:

--- a/gl-inet/gl-s10.yaml
+++ b/gl-inet/gl-s10.yaml
@@ -13,11 +13,6 @@ esp32:
   variant: esp32
   framework:
     type: esp-idf
-    # Workaround for BLE scanning regression (https://github.com/esphome/esphome/issues/13560)
-    # Remove once ESPHome 2026.2.0 is released
-    version: 5.5.2
-    release: "260206"
-    # end remove
 
 # Configuration fo V2.3 hardware revision
 ethernet:

--- a/lilygo/lilygo-t-eth-poe.yaml
+++ b/lilygo/lilygo-t-eth-poe.yaml
@@ -8,11 +8,6 @@ esp32:
   variant: esp32
   framework:
     type: esp-idf
-    # Workaround for BLE scanning regression (https://github.com/esphome/esphome/issues/13560)
-    # Remove once ESPHome 2026.2.0 is released
-    version: 5.5.2
-    release: "260206"
-    # end remove
 
 # See: https://esphome.io/components/ethernet.html#configuration-for-lilygo-ttgo-t-internet-poe-esp32-wroom-lan8270a-chip
 ethernet:

--- a/m5stack/m5stack-atom-lite.yaml
+++ b/m5stack/m5stack-atom-lite.yaml
@@ -8,11 +8,6 @@ esp32:
   variant: esp32
   framework:
     type: esp-idf
-    # Workaround for BLE scanning regression (https://github.com/esphome/esphome/issues/13560)
-    # Remove once ESPHome 2026.2.0 is released
-    version: 5.5.2
-    release: "260206"
-    # end remove
 
 wifi:
   ap:

--- a/m5stack/m5stack-atom-s3.yaml
+++ b/m5stack/m5stack-atom-s3.yaml
@@ -8,11 +8,6 @@ esp32:
   variant: esp32s3
   framework:
     type: esp-idf
-    # Workaround for BLE scanning regression (https://github.com/esphome/esphome/issues/13560)
-    # Remove once ESPHome 2026.2.0 is released
-    version: 5.5.2
-    release: "260206"
-    # end remove
 
 wifi:
   ap:

--- a/olimex/olimex-esp32-poe-iso.yaml
+++ b/olimex/olimex-esp32-poe-iso.yaml
@@ -8,11 +8,6 @@ esp32:
   variant: esp32
   framework:
     type: esp-idf
-    # Workaround for BLE scanning regression (https://github.com/esphome/esphome/issues/13560)
-    # Remove once ESPHome 2026.2.0 is released
-    version: 5.5.2
-    release: "260206"
-    # end remove
 
 ethernet:
   type: LAN8720

--- a/seeed/seeed-esp32-poe.yaml
+++ b/seeed/seeed-esp32-poe.yaml
@@ -9,11 +9,6 @@ esp32:
   variant: esp32s3
   framework:
     type: esp-idf
-    # Workaround for BLE scanning regression (https://github.com/esphome/esphome/issues/13560)
-    # Remove once ESPHome 2026.2.0 is released
-    version: 5.5.2
-    release: "260206"
-    # end remove
 
 ethernet:
   type: W5500

--- a/wt32/wt32-eth01.yaml
+++ b/wt32/wt32-eth01.yaml
@@ -10,11 +10,6 @@ esp32:
   variant: esp32
   framework:
     type: esp-idf
-    # Workaround for BLE scanning regression (https://github.com/esphome/esphome/issues/13560)
-    # Remove once ESPHome 2026.2.0 is released
-    version: 5.5.2
-    release: "260206"
-    # end remove
 
 ethernet:
   type: LAN8720


### PR DESCRIPTION
Revert "Pin ESP-IDF 5.5.2.260206 to fix BLE scanning regression (#158)"
This reverts commit 9b40f7a10315dc2798f8ec65877c6dfdf06e6062.

ESPHome 2026.3.0 is out and fixes issue.
From Release notes:
> **ESP-IDF 5.5.3:**
> 
> ESP-IDF has been bumped to 5.5.3 ([#14122](https://github.com/esphome/esphome/pull/14122)), fixing long-standing BLE bugs from 5.5.1 and 5.5.2 where Bluetooth would stop working on ESP32 devices.