### PR TITLE
Update m5stack-atom-lite.yaml to enable SRAM1 as IRAMsram1_as_iram: true

### DIFF
--- a/m5stack/m5stack-atom-lite.yaml
+++ b/m5stack/m5stack-atom-lite.yaml
@@ -8,6 +8,8 @@ esp32:
   variant: esp32
   framework:
     type: esp-idf
+    advanced:
+      sram1_as_iram: true
 
 wifi:
   ap:


### PR DESCRIPTION
Enable SRAM1 as IRAM for ESP32 configuration.