### PR TITLE
Bump esphome/workflows to 2026.8.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     # remaining devices each publish their own manifest via the empty-named
     # group. `groups` requires files to be listed explicitly — it is not
     # auto-discovered, since discovery would sweep every config into one group.
-    uses: esphome/workflows/.github/workflows/build-to-draft-release.yml@57a5927f9cdc5da7c40c702403eabeff6ab9856a  # 2026.8.0
+    uses: esphome/workflows/.github/workflows/build-to-draft-release.yml@0fdd5e311b7e744069166696072a1a9cbc5fbeb6  # 2026.8.1
     with:
       esphome-version: 2026.7.4
       groups: |

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   lock:
-    uses: esphome/workflows/.github/workflows/lock.yml@57a5927f9cdc5da7c40c702403eabeff6ab9856a  # 2026.8.0
+    uses: esphome/workflows/.github/workflows/lock.yml@0fdd5e311b7e744069166696072a1a9cbc5fbeb6  # 2026.8.1
     with:
       pr-close-days: 1
       issue-close-days: 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,5 +19,5 @@ jobs:
     # non-prerelease). The firmware directory defaults to the repository
     # name singularized (e.g. rf-proxies -> rf-proxy); set a
     # FIRMWARE_DIRECTORY repository variable to override it.
-    uses: esphome/workflows/.github/workflows/publish-firmware-to-r2.yml@57a5927f9cdc5da7c40c702403eabeff6ab9856a  # 2026.8.0
+    uses: esphome/workflows/.github/workflows/publish-firmware-to-r2.yml@0fdd5e311b7e744069166696072a1a9cbc5fbeb6  # 2026.8.1
     secrets: inherit

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,4 +19,4 @@ jobs:
     # Computes the next CalVer version (YY.M.N, reusing the current draft's
     # sequence number) and runs release-drafter with it. Reads this repo's
     # .github/release-drafter.yml for the changelog categories.
-    uses: esphome/workflows/.github/workflows/draft-calver-release.yml@57a5927f9cdc5da7c40c702403eabeff6ab9856a  # 2026.8.0
+    uses: esphome/workflows/.github/workflows/draft-calver-release.yml@0fdd5e311b7e744069166696072a1a9cbc5fbeb6  # 2026.8.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     # Patches the draft release's manifest assets with the final release
     # notes, then publishes it — all by release id, immune to the
     # draft-by-tag lookup and draft-untagging API pitfalls.
-    uses: esphome/workflows/.github/workflows/publish-draft-release.yml@57a5927f9cdc5da7c40c702403eabeff6ab9856a  # 2026.8.0
+    uses: esphome/workflows/.github/workflows/publish-draft-release.yml@0fdd5e311b7e744069166696072a1a9cbc5fbeb6  # 2026.8.1
     with:
       tag: ${{ inputs.tag }}
     secrets: inherit


### PR DESCRIPTION
# What does this implement/fix?

Bumps all five `esphome/workflows` reusable-workflow pins from 2026.8.0 (`57a5927`) to 2026.8.1 (`0fdd5e311b7e744069166696072a1a9cbc5fbeb6`).

The [26.8.1 Publish run](https://github.com/esphome/bluetooth-proxies/actions/runs/31760195480) failed for `gl-s10`, `olimex-esp32-poe-iso`, `lilygo-t-eth-poe` and `esp32-generic` in the "Download device assets and reconstruct layout" step, with `the response contains terminal escape sequences; pass --allow-escape-sequences to output it anyway`. `gh api` scans a response body for ANSI escape bytes before writing it to stdout and hard-fails instead of writing. Firmware `.bin` assets are arbitrary binary, so whether a given image happens to contain such a sequence is luck, which is why 5 of the 9 devices passed on identical code. The four failures then blocked `Upload to R2` and both promote jobs.

2026.8.1 passes `--allow-escape-sequences` at both release-asset download sites (`publish-firmware-to-r2.yml` and `publish-draft-release.yml`). That is the entire diff between the two tags.

All five callers were on the same SHA, so they move together rather than leaving four pins stale.

## Types of changes

<!-- Release notes are generated from PR labels, so apply the matching label as well. -->

- [ ] Bugfix (non-breaking change which fixes an issue) — label: `bugfix`
- [ ] New device (adds a configuration for a new device) — label: `new-device`
- [ ] Enhancement (non-breaking change which improves an existing configuration) — label: `enhancement`
- [ ] Breaking change (fix or change that alters existing behaviour, e.g. renamed entities or changed pins) — label: `breaking-change`
- [x] Dependency update (actions, reusable workflows or ESPHome version) — label: `dependencies`
- [ ] Other

**Related issue (if applicable):**

- fixes <link to issue>

## Checklist

- [ ] The configuration compiles and has been tested on the actual device. (n/a, no device configuration changed)
- [x] `yamllint --strict .` passes.

If a device configuration was added or renamed:

- [ ] The device directory contains both `<device>.yaml` (core config) and `<device>.factory.yaml` (factory wrapper).
- [ ] `dashboard_import.package_import_url` points to the core YAML in this repository.
- [ ] `update.source` points to the correct `https://firmware.esphome.io/<directory>/<device>/manifest.json` URL.
- [ ] The factory YAML is named `<device>.factory.yaml` so CI picks it up automatically.
- [ ] The device is listed in the dropdown in `.github/ISSUE_TEMPLATE/bug_report.yml`.
- [ ] The README is updated if it lists supported devices.